### PR TITLE
substitute (plain|raw) by (ascii|binary) in sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ A Fortran library for reading and writing images.
 - [x] pbm (ASCII/plain)
 - [x] pgm (ASCII/plain)
 - [x] ppm (ASCII/plain)
-- [ ] pbm (Binary/raw)
-- [ ] pgm (Binary/raw)
-- [ ] ppm (Binary/raw)
+- [ ] pbm (binary/raw)
+- [ ] pgm (binary/raw)
+- [ ] ppm (binary/raw)
 
 Please note that ForImage is currently under development.
 

--- a/example/example1.f90
+++ b/example/example1.f90
@@ -16,10 +16,10 @@ program example1
     px(9,:)  = [0,0,0,0,0,0]
     px(10,:) = [0,0,0,0,0,0]
 
-    call ex1%set_pnm(encoding='plain', file_format='pbm', width=10, height=6, comment='example 1', pixels=px)
+    call ex1%set_pnm(encoding='ascii', file_format='pbm', width=10, height=6, comment='example 1', pixels=px)
     call ex1%export_pnm('pnm_files/example1')
 
-    call ex1%import_pnm('pnm_files/example1','pbm','plain')
+    call ex1%import_pnm('pnm_files/example1','pbm','ascii')
     call ex1%export_pnm('pnm_files/example1_ex')
 
     call ex1%dlloc()

--- a/example/example2.f90
+++ b/example/example2.f90
@@ -3608,10 +3608,10 @@ program example2
     255]&
     ,shape=shape(px)))
 
-    call ex2%set_pnm(encoding='plain', file_format='pgm', width=60, height=60, max_color=255, comment='example 2', pixels=px)
+    call ex2%set_pnm(encoding='ascii', file_format='pgm', width=60, height=60, max_color=255, comment='example 2', pixels=px)
     call ex2%export_pnm('pnm_files/example2')
 
-    call ex2%import_pnm('pnm_files/example2','pgm','plain')
+    call ex2%import_pnm('pnm_files/example2','pgm','ascii')
     call ex2%export_pnm('pnm_files/example2_ex')
 
     call ex2%dlloc()

--- a/example/example3.f90
+++ b/example/example3.f90
@@ -10,10 +10,10 @@ program example3
     px(3,:)  = [0,0,0,0,0,0,0,15,7,0,0,0]
     px(4,:)  = [15,0,15,0,0,0,0,0,0,0,0,0]
 
-    call ex3%set_pnm(encoding='plain', file_format='ppm', width=4, height=4, max_color=15, comment='example 2', pixels=px)
+    call ex3%set_pnm(encoding='ascii', file_format='ppm', width=4, height=4, max_color=15, comment='example 2', pixels=px)
     call ex3%export_pnm('pnm_files/example3')
 
-    call ex3%import_pnm('pnm_files/example3','ppm','plain')
+    call ex3%import_pnm('pnm_files/example3','ppm','ascii')
     call ex3%export_pnm('pnm_files/example3_ex')
 
     call ex3%dlloc()

--- a/src/forimage.f90
+++ b/src/forimage.f90
@@ -80,7 +80,7 @@ contains
       this%encoding = encoding
 
       select case (encoding)
-      case ('raw')
+      case ('binary')
          
          print*, 'Error: not implementet yet!'
 
@@ -93,7 +93,7 @@ contains
 
          end select
 
-      case ('plain')
+      case ('ascii')
 
          select case (file_format)
          case ('pbm')
@@ -150,7 +150,7 @@ contains
       character(2)                        :: magic_number
 
       select case (encoding)
-      case ('plain')
+      case ('ascii')
          select case (file_format)
          case ('pbm')
             magic_number = 'P1'
@@ -159,7 +159,7 @@ contains
          case ('ppm')
             magic_number = 'P3'
          end select
-      case ('raw')
+      case ('binary')
          error stop 'Error: not implementet yet!'
          select case (file_format)
          case ('pbm')

--- a/src/forimage.f90
+++ b/src/forimage.f90
@@ -80,7 +80,7 @@ contains
       this%encoding = encoding
 
       select case (encoding)
-      case ('binary')
+      case ('binary','raw')
          
          print*, 'Error: not implementet yet!'
 
@@ -93,7 +93,7 @@ contains
 
          end select
 
-      case ('ascii')
+      case ('ascii','plain')
 
          select case (file_format)
          case ('pbm')
@@ -150,7 +150,7 @@ contains
       character(2)                        :: magic_number
 
       select case (encoding)
-      case ('ascii')
+      case ('ascii','plain')
          select case (file_format)
          case ('pbm')
             magic_number = 'P1'
@@ -159,7 +159,7 @@ contains
          case ('ppm')
             magic_number = 'P3'
          end select
-      case ('binary')
+      case ('binary','raw')
          error stop 'Error: not implementet yet!'
          select case (file_format)
          case ('pbm')


### PR DESCRIPTION
Often, `raw` is used e.g. in `raw data` and hence, as an antonym
of `processed data`.  Hence, either `ascii` or `binary` to specify
the type of .ppm, .pbm, .pgm are easier to retain in memory.

Signed-off-by: Norwid Behrnd <nbehrnd@yahoo.com>

